### PR TITLE
fix: requirements parsing adapted to newer pip versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ install_reqs = parse_requirements('requirements.txt', session=False)
 
 # reqs is a list of requirement
 # e.g. ['django==1.5.1', 'mezzanine==1.4.6']
-reqs = [str(ir.req) for ir in install_reqs]
+# Newer pip versions use the ParsedRequirement class which has the `requirement` attribute instead of `req`
+try:
+    reqs = [str(ir.req) for ir in install_reqs]
+except AttributeError:
+    reqs = [str(ir.requirement) for ir in install_reqs]
 
 setup(
     name='atmos',


### PR DESCRIPTION
Every time I tried to install the develop version of the atmos package either via `pip install` or `pipenv install`, I was facing an error most likely related to the issue that was addresed in issue #8. The `req` module has been moved to the `pip._internal.req` submodule, so the try except in `setup.py` seems to solve the issue of importing the `parse_requirements` function.

However, some extra changes might have happened on the  `pip` side, because apparently, now, the `ParsedRequirement` class has had its `req` attribute renamed to `requirement`, which caused an `AttributeError`. 

I solved this in my machine via another try and except clause that should handle older and newer pip versions, feel free to include this in the main develop branch!